### PR TITLE
Bug fix for Issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WiX Toolset Examples
 by Stephen P. Lepisto
 
-### Copyright (c) 2024 Stephen P. Lepisto
+### Copyright (c) 2024-2025 Stephen P. Lepisto
 ### Licensed under the MIT License.  See LICENSE.md for details.
 
 -------------------------------------------------------------------------------
@@ -118,11 +118,21 @@ interesting features.
    
    Download from https://gitforwindows.org/
 
-4. WiX.Toolset.ui.wixext NuGet package version 5.0.1
+4. WiX.Toolset.ui.wixext NuGet package version 5.0.2
 
    This is automatically installed when the `wixtoolsetexamples` solution is
    first loaded into Visual Studio on a system without the WiX extension
    already installed.
+
+   _Note: __as of version 6__, the WiX Toolset requires an Open Source Maintainer
+   Fee (see https://robmensching.com/blog/posts/2025/02/26/introducing-the-open-source-maintenance-fee/).
+   For projects that use the WiX Toolset and are intended to generate income,
+   the Maintainer Fee is required.  This is a reasonable fee and is likely to
+   become more prevalent across open source projects in the years to come.
+   See also: https://opensourcemaintenancefee.org/._
+
+   The WiX Toolset Examples project does not generate any income but the build
+   requirements are holding with WiX Toolset version 5 for now.
    
 5. WiX.Toolset.SDK NuGet package
    
@@ -221,11 +231,19 @@ There are three ways to launch the installer file:
 3. From a Command Prompt, run the msiexec program with the path to the installer
    file as the argument.  For example:
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   msiexec %HOMEPATH%\work\wixtoolsetexamples\build\setup\x64\Release\en-US\SimpleAppSetup-min.msi
+   msiexec /i %HOMEPATH%\work\wixtoolsetexamples\build\setup\x64\Release\en-US\SimpleAppSetup-min.msi
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+   _Note: Using msiexec directly allows for generating a log file that is useful
+   for debugging.  For full logging, add the following to the end of the above
+   call to msiexec:_
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   /lv*vx install.log
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
 ## To Uninstall SimpleApp
-There are three basic ways to uninstall SimpleApp after it is installed.
+There are four basic ways to uninstall SimpleApp after it is installed.
 1. Right-click on the Windows Start icon and select _Apps and Features_, then
    type "SimpleApp" in the search box, click on the found entry and click the
    _Uninstall_ button.
@@ -235,6 +253,17 @@ There are three basic ways to uninstall SimpleApp after it is installed.
 3. Run the installer file (see the __To Install SimpleApp__ section), click the
    Next button, click the Remove button, and click the Remove button (again),
    and finally, click the Finish button to close the installer.
+4. Use msiexec to perform an uninstall:
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   msiexec /x %HOMEPATH%\work\wixtoolsetexamples\build\setup\x64\Release\en-US\SimpleAppSetup-min.msi
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   _Note: Using msiexec directly allows for generating a log file that is useful
+   for debugging.  For full logging, add the following to the end of the above
+   call to msiexec:_
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   /lv*vx uninstall.log
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # The WiX Install Type Templates
 _WiXUI dialog library documentation: https://wixtoolset.org/docs/tools/wixext/wixui/_
@@ -372,8 +401,9 @@ Studio 2022.
 1. In VS2022, in Solution Explorer, right-click on the existing solution
     (with a project to install) and select `Add` > `New Project`.
 2. In the search box, type "Heatwave" to show the HeatWave-based project
-    project types (these correspond to Wix Toolkit v4).
-    _Note: If you look for Wix, you will see the templates for Wix Toolkit
+    types (these correspond to Wix Toolkit v4).
+
+    _Note: If you look for "Wix", you will see the templates for Wix Toolkit
     v3, which are the older type._
 3. Select the `MSI Package` and click `Next`.
 4. Enter a project name and verify where the project is to be created
@@ -401,6 +431,9 @@ Studio 2022.
     Make sure the `include prerelease` checkbox is cleared!
 4. On the right, select the install project then select the
     "Latest Stable vx.x" from the second dropdown under the projects box.
+
+    _Note: The WiX Toolset Examples use Wix.Toolset.ui.wixext v5.0.2 and not
+    the latest version._
 5. Click the `Install` button then click the `Apply` button (if shown).
 6. Done.
 
@@ -433,3 +466,9 @@ Studio 2022.
       `Wix Toolset.UI`
    4. Close the "Dependencies" scope.
 3. Done.
+
+_Note: The WiX Toolset Examples use a file called Predefines.wxi to define
+elements in a single location that are used in several places in the other
+files.  If you use this approach, each of the setup project files needs to
+include the Predefines.wxi file.  Naturally, see the WiX Toolset Examples for
+how this is done._

--- a/SimpleAppSetup-adv/Components.wxs
+++ b/SimpleAppSetup-adv/Components.wxs
@@ -34,41 +34,83 @@
     <Fragment>
         <ComponentGroup Id="Components" Directory="APPLICATIONFOLDER">
             <Component Guid="$(var.ProductComponentGUID)">
-                <!-- The file represented by this component -->
-                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" Checksum="yes" />
+                <!--
+                    The file represented by this component.
+                    
+                    The file's location is used as the key path.  If the key
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Note: During uninstall, the file is removed by the Windows
+                    Installer.  In addition, the file's parent directories are
+                    removed so long as the parent directories are empty.  There
+                    is no need to explicitly remove the installation directory
+                    in this case.
+                -->
+                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" KeyPath="yes" Checksum="yes" />
+            </Component>
+            <!--
+                Shortcuts need to be defined in their own component so they do
+                not interfere with installation of the application file to a
+                custom location.  Specifically, short cuts somehow interfere
+                with the application file being removed during uninstall.
+                
+                The shortcuts are still installed and uninstalled with the
+                application because it is the ComponentGroup that is associated
+                with the Main feature (in Package.wxs) and that includes all
+                the Components in the ComponentGroup.
+                
+                Note: The Directory value is used on all elements defined in
+                the Component unless an element overrides the value with its
+                own Directory value (not done in this example).
+                
+                Note: Use of [!SimpleAppexe] (instead of [#SimpleAppexe]) gets
+                around warning ICE69, where one component is cross-referencing
+                something in another component and both components are defined
+                in the same feature or component group.  Cross-referencing is
+                generally an error but in the specific case of shortcuts where
+                the shortcut is closely associated with the cross-referenced
+                name, this is a "safe" warning.  Using [!] essentially hides
+                the warning in this specific case.
+
+                ApplicationProgramsFolder defined in Folders.wxs.
+            -->
+            <Component Id="Shortcuts" Directory="ApplicationProgramsFolder">
                 <!-- Start Menu shortcut to run the program -->
-                <Shortcut Id="ApplicationStartMenuShortcut" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="ApplicationStartMenuShortcut" Advertise="no"
                     Icon="icon.ico" Name="$(var.Name)"
                     Description="Launch $(var.Name) application"
-                    Target="[#SimpleAppexe]"
+                    Target="[!SimpleAppexe]"
                     Arguments="--pause"
                     WorkingDirectory="APPLICATIONFOLDER" />
                 <!-- Start Menu shortcut to uninstall the program -->
-                <Shortcut Id="UninstallProduct" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="UninstallProduct" Advertise="no"
                     Icon="icon.ico"
                     Name="$(var.Name) uninstall"
                     Description="Uninstalls $(var.Name)"
                     Target="[System64Folder]msiexec.exe"
                     Arguments="/x [ProductCode]" />
                 <!--
-                    Program folder to remove during uninstall.
-                    INSTALLFOLDER defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="APPLICATIONFOLDER" On="uninstall" />
-                <!--
-                    Start Menu folder to remove during uninstall.
-                    ApplicationProgramsFolder defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="ApplicationProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
-                <!--
                     Define the key path for the parent component.  If the key
-                    path is not present, the component is not installed;
-                    otherwise, if the key path is present, the installer
-                    performs an upgrade, repair, or remove.
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Shortcuts require a registry-based key path; the
+                    application's own path can be a key path but that key path
+                    cannot be used with shortcuts.
 
                     Note: A key path must be unique across all components.
                 -->
                 <RegistryValue Root="HKCU" Key="Software\$(var.Manufacturer)\$(var.Name)" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+                <!--
+                    Start Menu folder to remove during uninstall.  This removes
+                    the shortcuts.  For shortcuts, the remove folder step must
+                    be explicitly given, unlike components that contain
+                    explicit files.
+                -->
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />
             </Component>
         </ComponentGroup>
         <!--

--- a/SimpleAppSetup-cus/Components.wxs
+++ b/SimpleAppSetup-cus/Components.wxs
@@ -34,42 +34,83 @@
     <Fragment>
         <ComponentGroup Id="Components" Directory="INSTALLFOLDER">
             <Component Guid="$(var.ProductComponentGUID)">
-                <!-- The file represented by this component -->
-                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" Checksum="yes" />
+                <!--
+                    The file represented by this component.
+                    
+                    The file's location is used as the key path.  If the key
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Note: During uninstall, the file is removed by the Windows
+                    Installer.  In addition, the file's parent directories are
+                    removed so long as the parent directories are empty.  There
+                    is no need to explicitly remove the installation directory
+                    in this case.
+                -->
+                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" KeyPath="yes" Checksum="yes" />
+            </Component>
+            <!--
+                Shortcuts need to be defined in their own component so they do
+                not interfere with installation of the application file to a
+                custom location.  Specifically, short cuts somehow interfere
+                with the application file being removed during uninstall.
+                
+                The shortcuts are still installed and uninstalled with the
+                application because it is the ComponentGroup that is associated
+                with the Main feature (in Package.wxs) and that includes all
+                the Components in the ComponentGroup.
+                
+                Note: The Directory value is used on all elements defined in
+                the Component unless an element overrides the value with its
+                own Directory value (not done in this example).
+                
+                Note: The target uses [!SimpleAppexe] to get around an ICE69
+                warning complaining that [#SimpleAppexe] references a file
+                in another component (but both components are in the same
+                feature; if the components were in separate features, the
+                warning would become an error).  Using [!] apparently
+                bypasses the ICE69 check and, in this case, the target is a
+                file not a registry value so [!] is basically treated the
+                same as [#].  Yes, this is a hack.
+                    
+                ApplicationProgramsFolder defined in Folders.wxs.
+            -->
+            <Component Id="Shortcuts" Directory="ApplicationProgramsFolder">
                 <!-- Start Menu shortcut to run the program -->
-                <Shortcut Id="ApplicationStartMenuShortcut" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="ApplicationStartMenuShortcut" Advertise="no"
                     Icon="icon.ico" Name="$(var.Name)"
                     Description="Launch $(var.Name) application"
-                    Target="[#SimpleAppexe]"
+                    Target="[!SimpleAppexe]"
                     Arguments="--pause"
                     WorkingDirectory="INSTALLFOLDER" />
                 <!-- Start Menu shortcut to uninstall the program -->
-                <Shortcut Id="UninstallProduct" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="UninstallProduct" Advertise="no"
                     Icon="icon.ico"
                     Name="$(var.Name) uninstall"
                     Description="Uninstalls $(var.Name)"
                     Target="[System64Folder]msiexec.exe"
                     Arguments="/x [ProductCode]" />
-               
-                <!--
-                    Program folder to remove during uninstall.
-                    INSTALLFOLDER defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="INSTALLFOLDER" On="uninstall" />
-                <!--
-                    Start Menu folder to remove during uninstall.
-                    ApplicationProgramsFolder defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="ApplicationProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
                 <!--
                     Define the key path for the parent component.  If the key
-                    path is not present, the component is not installed;
-                    otherwise, if the key path is present, the installer
-                    performs an upgrade, repair, or remove.
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Shortcuts require a registry-based key path; the
+                    application's own path can be a key path but that key path
+                    cannot be used with shortcuts.
 
                     Note: A key path must be unique across all components.
                 -->
                 <RegistryValue Root="HKCU" Key="Software\$(var.Manufacturer)\$(var.Name)" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+                <!--
+                    Start Menu folder to remove during uninstall.  This removes
+                    the shortcuts.  For shortcuts, the remove folder step must
+                    be explicitly given, unlike components that contain
+                    explicit files.
+                -->
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />
             </Component>
 
             <Component Directory="DesktopFolder" Condition="ADDDESKTOPSHORTCUT">

--- a/SimpleAppSetup-cus/Folders.wxs
+++ b/SimpleAppSetup-cus/Folders.wxs
@@ -23,16 +23,22 @@
         <StandardDirectory Id="ProgramFiles6432Folder">
             <!--
                 This dictates the name of the folder where the application file
-                is to be installed.  32-bit and 64-bit versions end up in
-                different root folders (due to the ProgramFiles6432Folder ID
-                above), so a simplified name is okay.  So use
-                $(var.InstallFolderName) instead of !(bind.Property.ProductName).
-                Also, add a '\' between the Manufacturer and the application
-                folder name.
-            
-                INSTALLFOLDER is defined in Predefines.wxi.
+                is to be installed by default.  32-bit and 64-bit versions end
+                up in different root folders (due to the ProgramFiles6432Folder
+                ID above), so a simplified name is okay, which means using a
+                variable $(var.InstallFolderName) instead of a property
+                !(bind.Property.ProductName).
                 
-                Note: bind.Property.ProductName comes from <Package Name="">.
+                Also, remember to add a '\' between the Manufacturer and the
+                application folder name since a folder is being defined here.
+                This way, it is possible to install to an entirely different
+                parent folder from C:\Program Files\[Manufacturer] but still
+                use the InstallFolderName as a sub-folder.
+            
+                InstallFolderName is defined in Predefines.wxi.
+                
+                Note: the Manufacturer property comes from the
+                <Package Manufacturer=""> value.
             -->
             <Directory Id="INSTALLFOLDER" Name="!(bind.Property.Manufacturer)\$(var.InstallFolderName)" />
         </StandardDirectory>

--- a/SimpleAppSetup-fea/Components.wxs
+++ b/SimpleAppSetup-fea/Components.wxs
@@ -34,41 +34,83 @@
     <Fragment>
         <ComponentGroup Id="Components" Directory="INSTALLFOLDER">
             <Component Guid="$(var.ProductComponentGUID)">
-                <!-- The file represented by this component -->
-                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" Checksum="yes" />
+                <!--
+                    The file represented by this component.
+                    
+                    The file's location is used as the key path.  If the key
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Note: During uninstall, the file is removed by the Windows
+                    Installer.  In addition, the file's parent directories are
+                    removed so long as the parent directories are empty.  There
+                    is no need to explicitly remove the installation directory
+                    in this case.
+                -->
+                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" KeyPath="yes" Checksum="yes" />
+            </Component>
+            <!--
+                Shortcuts need to be defined in their own component so they do
+                not interfere with installation of the application file to a
+                custom location.  Specifically, short cuts somehow interfere
+                with the application file being removed during uninstall.
+                
+                The shortcuts are still installed and uninstalled with the
+                application because it is the ComponentGroup that is associated
+                with the Main feature (in Package.wxs) and that includes all
+                the Components in the ComponentGroup.
+                
+                Note: The Directory value is used on all elements defined in
+                the Component unless an element overrides the value with its
+                own Directory value (not done in this example).
+                
+                Note: The target uses [!SimpleAppexe] to get around an ICE69
+                warning complaining that [#SimpleAppexe] references a file
+                in another component (but both components are in the same
+                feature; if the components were in separate features, the
+                warning would become an error).  Using [!] apparently
+                bypasses the ICE69 check and, in this case, the target is a
+                file not a registry value so [!] is basically treated the
+                same as [#].  Yes, this is a hack.
+                    
+                ApplicationProgramsFolder defined in Folders.wxs.
+            -->
+            <Component Id="Shortcuts" Directory="ApplicationProgramsFolder">
                 <!-- Start Menu shortcut to run the program -->
-                <Shortcut Id="ApplicationStartMenuShortcut" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="ApplicationStartMenuShortcut" Advertise="no"
                     Icon="icon.ico" Name="$(var.Name)"
                     Description="Launch $(var.Name) application"
-                    Target="[#SimpleAppexe]"
+                    Target="[!SimpleAppexe]"
                     Arguments="--pause"
                     WorkingDirectory="INSTALLFOLDER" />
                 <!-- Start Menu shortcut to uninstall the program -->
-                <Shortcut Id="UninstallProduct" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="UninstallProduct" Advertise="no"
                     Icon="icon.ico"
                     Name="$(var.Name) uninstall"
                     Description="Uninstalls $(var.Name)"
                     Target="[System64Folder]msiexec.exe"
                     Arguments="/x [ProductCode]" />
                 <!--
-                    Program folder to remove during uninstall.
-                    INSTALLFOLDER defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="INSTALLFOLDER" On="uninstall" />
-                <!--
-                    Start Menu folder to remove during uninstall.
-                    ApplicationProgramsFolder defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="ApplicationProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
-                <!--
                     Define the key path for the parent component.  If the key
-                    path is not present, the component is not installed;
-                    otherwise, if the key path is present, the installer
-                    performs an upgrade, repair, or remove.
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Shortcuts require a registry-based key path; the
+                    application's own path can be a key path but that key path
+                    cannot be used with shortcuts.
 
                     Note: A key path must be unique across all components.
                 -->
                 <RegistryValue Root="HKCU" Key="Software\$(var.Manufacturer)\$(var.Name)" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+                <!--
+                    Start Menu folder to remove during uninstall.  This removes
+                    the shortcuts.  For shortcuts, the remove folder step must
+                    be explicitly given, unlike components that contain
+                    explicit files.
+                -->
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />
             </Component>
         </ComponentGroup>
         <!--

--- a/SimpleAppSetup-fea/Folders.wxs
+++ b/SimpleAppSetup-fea/Folders.wxs
@@ -23,16 +23,22 @@
         <StandardDirectory Id="ProgramFiles6432Folder">
             <!--
                 This dictates the name of the folder where the application file
-                is to be installed.  32-bit and 64-bit versions end up in
-                different root folders (due to the ProgramFiles6432Folder ID
-                above), so a simplified name is okay.  So use
-                $(var.InstallFolderName) instead of !(bind.Property.ProductName).
-                Also, add a '\' between the Manufacturer and the application
-                folder name.
-            
-                INSTALLFOLDER is defined in Predefines.wxi.
+                is to be installed by default.  32-bit and 64-bit versions end
+                up in different root folders (due to the ProgramFiles6432Folder
+                ID above), so a simplified name is okay, which means using a
+                variable $(var.InstallFolderName) instead of a property
+                !(bind.Property.ProductName).
                 
-                Note: bind.Property.ProductName comes from <Package Name="">.
+                Also, remember to add a '\' between the Manufacturer and the
+                application folder name since a folder is being defined here.
+                This way, it is possible to install to an entirely different
+                parent folder from C:\Program Files\[Manufacturer] but still
+                use the InstallFolderName as a sub-folder.
+            
+                InstallFolderName is defined in Predefines.wxi.
+                
+                Note: the Manufacturer property comes from the
+                <Package Manufacturer=""> value.
             -->
             <Directory Id="INSTALLFOLDER" Name="!(bind.Property.Manufacturer)\$(var.InstallFolderName)" />
         </StandardDirectory>

--- a/SimpleAppSetup-ins/Components.wxs
+++ b/SimpleAppSetup-ins/Components.wxs
@@ -34,41 +34,83 @@
     <Fragment>
         <ComponentGroup Id="Components" Directory="INSTALLFOLDER">
             <Component Guid="$(var.ProductComponentGUID)">
-                <!-- The file represented by this component -->
-                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" Checksum="yes" />
+                <!--
+                    The file represented by this component.
+                    
+                    The file's location is used as the key path.  If the key
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Note: During uninstall, the file is removed by the Windows
+                    Installer.  In addition, the file's parent directories are
+                    removed so long as the parent directories are empty.  There
+                    is no need to explicitly remove the installation directory
+                    in this case.
+                -->
+                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" KeyPath="yes" Checksum="yes" />
+            </Component>
+            <!--
+                Shortcuts need to be defined in their own component so they do
+                not interfere with installation of the application file to a
+                custom location.  Specifically, short cuts somehow interfere
+                with the application file being removed during uninstall.
+                
+                The shortcuts are still installed and uninstalled with the
+                application because it is the ComponentGroup that is associated
+                with the Main feature (in Package.wxs) and that includes all
+                the Components in the ComponentGroup.
+                
+                Note: The Directory value is used on all elements defined in
+                the Component unless an element overrides the value with its
+                own Directory value (not done in this example).
+                
+                Note: The target uses [!SimpleAppexe] to get around an ICE69
+                warning complaining that [#SimpleAppexe] references a file
+                in another component (but both components are in the same
+                feature; if the components were in separate features, the
+                warning would become an error).  Using [!] apparently
+                bypasses the ICE69 check and, in this case, the target is a
+                file not a registry value so [!] is basically treated the
+                same as [#].  Yes, this is a hack.
+                    
+                ApplicationProgramsFolder defined in Folders.wxs.
+            -->
+            <Component Id="Shortcuts" Directory="ApplicationProgramsFolder">
                 <!-- Start Menu shortcut to run the program -->
-                <Shortcut Id="ApplicationStartMenuShortcut" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="ApplicationStartMenuShortcut" Advertise="no"
                     Icon="icon.ico" Name="$(var.Name)"
                     Description="Launch $(var.Name) application"
-                    Target="[#SimpleAppexe]"
+                    Target="[!SimpleAppexe]"
                     Arguments="--pause"
                     WorkingDirectory="INSTALLFOLDER" />
                 <!-- Start Menu shortcut to uninstall the program -->
-                <Shortcut Id="UninstallProduct" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="UninstallProduct" Advertise="no"
                     Icon="icon.ico"
                     Name="$(var.Name) uninstall"
                     Description="Uninstalls $(var.Name)"
                     Target="[System64Folder]msiexec.exe"
                     Arguments="/x [ProductCode]" />
                 <!--
-                    Program folder to remove during uninstall.
-                    INSTALLFOLDER defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="INSTALLFOLDER" On="uninstall" />
-                <!--
-                    Start Menu folder to remove during uninstall.
-                    ApplicationProgramsFolder defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="ApplicationProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
-                <!--
                     Define the key path for the parent component.  If the key
-                    path is not present, the component is not installed;
-                    otherwise, if the key path is present, the installer
-                    performs an upgrade, repair, or remove.
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Shortcuts require a registry-based key path; the
+                    application's own path can be a key path but that key path
+                    cannot be used with shortcuts.
 
                     Note: A key path must be unique across all components.
                 -->
                 <RegistryValue Root="HKCU" Key="Software\$(var.Manufacturer)\$(var.Name)" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+                <!--
+                    Start Menu folder to remove during uninstall.  This removes
+                    the shortcuts.  For shortcuts, the remove folder step must
+                    be explicitly given, unlike components that contain
+                    explicit files.
+                -->
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />
             </Component>
         </ComponentGroup>
         <!--

--- a/SimpleAppSetup-ins/Folders.wxs
+++ b/SimpleAppSetup-ins/Folders.wxs
@@ -23,16 +23,22 @@
         <StandardDirectory Id="ProgramFiles6432Folder">
             <!--
                 This dictates the name of the folder where the application file
-                is to be installed.  32-bit and 64-bit versions end up in
-                different root folders (due to the ProgramFiles6432Folder ID
-                above), so a simplified name is okay.  So use
-                $(var.InstallFolderName) instead of !(bind.Property.ProductName).
-                Also, add a '\' between the Manufacturer and the application
-                folder name.
-            
-                INSTALLFOLDER is defined in Predefines.wxi.
+                is to be installed by default.  32-bit and 64-bit versions end
+                up in different root folders (due to the ProgramFiles6432Folder
+                ID above), so a simplified name is okay, which means using a
+                variable $(var.InstallFolderName) instead of a property
+                !(bind.Property.ProductName).
                 
-                Note: bind.Property.ProductName comes from <Package Name="">.
+                Also, remember to add a '\' between the Manufacturer and the
+                application folder name since a folder is being defined here.
+                This way, it is possible to install to an entirely different
+                parent folder from C:\Program Files\[Manufacturer] but still
+                use the InstallFolderName as a sub-folder.
+            
+                InstallFolderName is defined in Predefines.wxi.
+                
+                Note: the Manufacturer property comes from the
+                <Package Manufacturer=""> value.
             -->
             <Directory Id="INSTALLFOLDER" Name="!(bind.Property.Manufacturer)\$(var.InstallFolderName)" />
         </StandardDirectory>

--- a/SimpleAppSetup-min/Components.wxs
+++ b/SimpleAppSetup-min/Components.wxs
@@ -34,41 +34,83 @@
     <Fragment>
         <ComponentGroup Id="Components" Directory="INSTALLFOLDER">
             <Component Guid="$(var.ProductComponentGUID)">
-                <!-- The file represented by this component -->
-                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" Checksum="yes" />
+                <!--
+                    The file represented by this component.
+                    
+                    The file's location is used as the key path.  If the key
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Note: During uninstall, the file is removed by the Windows
+                    Installer.  In addition, the file's parent directories are
+                    removed so long as the parent directories are empty.  There
+                    is no need to explicitly remove the installation directory
+                    in this case.
+                -->
+                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" KeyPath="yes" Checksum="yes" />
+            </Component>
+            <!--
+                Shortcuts need to be defined in their own component so they do
+                not interfere with installation of the application file to a
+                custom location.  Specifically, short cuts somehow interfere
+                with the application file being removed during uninstall.
+                
+                The shortcuts are still installed and uninstalled with the
+                application because it is the ComponentGroup that is associated
+                with the Main feature (in Package.wxs) and that includes all
+                the Components in the ComponentGroup.
+                
+                Note: The Directory value is used on all elements defined in
+                the Component unless an element overrides the value with its
+                own Directory value (not done in this example).
+                
+                Note: The target uses [!SimpleAppexe] to get around an ICE69
+                warning complaining that [#SimpleAppexe] references a file
+                in another component (but both components are in the same
+                feature; if the components were in separate features, the
+                warning would become an error).  Using [!] apparently
+                bypasses the ICE69 check and, in this case, the target is a
+                file not a registry value so [!] is basically treated the
+                same as [#].  Yes, this is a hack.
+                    
+                ApplicationProgramsFolder defined in Folders.wxs.
+            -->
+            <Component Id="Shortcuts" Directory="ApplicationProgramsFolder">
                 <!-- Start Menu shortcut to run the program -->
-                <Shortcut Id="ApplicationStartMenuShortcut" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="ApplicationStartMenuShortcut" Advertise="no"
                     Icon="icon.ico" Name="$(var.Name)"
                     Description="Launch $(var.Name) application"
-                    Target="[#SimpleAppexe]"
+                    Target="[!SimpleAppexe]"
                     Arguments="--pause"
                     WorkingDirectory="INSTALLFOLDER" />
                 <!-- Start Menu shortcut to uninstall the program -->
-                <Shortcut Id="UninstallProduct" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="UninstallProduct" Advertise="no"
                     Icon="icon.ico"
                     Name="$(var.Name) uninstall"
                     Description="Uninstalls $(var.Name)"
                     Target="[System64Folder]msiexec.exe"
                     Arguments="/x [ProductCode]" />
                 <!--
-                    Program folder to remove during uninstall.
-                    INSTALLFOLDER defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="INSTALLFOLDER" On="uninstall" />
-                <!--
-                    Start Menu folder to remove during uninstall.
-                    ApplicationProgramsFolder defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="ApplicationProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
-                <!--
                     Define the key path for the parent component.  If the key
-                    path is not present, the component is not installed;
-                    otherwise, if the key path is present, the installer
-                    performs an upgrade, repair, or remove.
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Shortcuts require a registry-based key path; the
+                    application's own path can be a key path but that key path
+                    cannot be used with shortcuts.
 
                     Note: A key path must be unique across all components.
                 -->
                 <RegistryValue Root="HKCU" Key="Software\$(var.Manufacturer)\$(var.Name)" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+                <!--
+                    Start Menu folder to remove during uninstall.  This removes
+                    the shortcuts.  For shortcuts, the remove folder step must
+                    be explicitly given, unlike components that contain
+                    explicit files.
+                -->
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />
             </Component>
         </ComponentGroup>
         <!--

--- a/SimpleAppSetup-min/Folders.wxs
+++ b/SimpleAppSetup-min/Folders.wxs
@@ -23,16 +23,22 @@
         <StandardDirectory Id="ProgramFiles6432Folder">
             <!--
                 This dictates the name of the folder where the application file
-                is to be installed.  32-bit and 64-bit versions end up in
-                different root folders (due to the ProgramFiles6432Folder ID
-                above), so a simplified name is okay.  So use
-                $(var.InstallFolderName) instead of !(bind.Property.ProductName).
-                Also, add a '\' between the Manufacturer and the application
-                folder name.
-            
-                INSTALLFOLDER is defined in Predefines.wxi.
+                is to be installed by default.  32-bit and 64-bit versions end
+                up in different root folders (due to the ProgramFiles6432Folder
+                ID above), so a simplified name is okay, which means using a
+                variable $(var.InstallFolderName) instead of a property
+                !(bind.Property.ProductName).
                 
-                Note: bind.Property.ProductName comes from <Package Name="">.
+                Also, remember to add a '\' between the Manufacturer and the
+                application folder name since a folder is being defined here.
+                This way, it is possible to install to an entirely different
+                parent folder from C:\Program Files\[Manufacturer] but still
+                use the InstallFolderName as a sub-folder.
+            
+                InstallFolderName is defined in Predefines.wxi.
+                
+                Note: the Manufacturer property comes from the
+                <Package Manufacturer=""> value.
             -->
             <Directory Id="INSTALLFOLDER" Name="!(bind.Property.Manufacturer)\$(var.InstallFolderName)" />
         </StandardDirectory>

--- a/SimpleAppSetup-mon/Components.wxs
+++ b/SimpleAppSetup-mon/Components.wxs
@@ -64,6 +64,15 @@
                 Note: The Directory value is used on all elements defined in
                 the Component unless an element overrides the value with its
                 own Directory value (not done in this example).
+                
+                Note: Use of [!SimpleAppexe] (instead of [#SimpleAppexe]) gets
+                around warning ICE69, where one component is cross-referencing
+                something in another component and both components are defined
+                in the same feature or component group.  Cross-referencing is
+                generally an error but in the specific case of shortcuts where
+                the shortcut is closely associated with the cross-referenced
+                name, this is a "safe" warning.  Using [!] essentially hides
+                the warning in this specific case.
                     
                 ApplicationProgramsFolder defined in Folders.wxs.
             -->
@@ -72,7 +81,7 @@
                 <Shortcut Id="ApplicationStartMenuShortcut" Advertise="no"
                     Icon="icon.ico" Name="$(var.Name)"
                     Description="Launch $(var.Name) application"
-                    Target="[#SimpleAppexe]"
+                    Target="[!SimpleAppexe]"
                     Arguments="--pause"
                     WorkingDirectory="INSTALLFOLDER" />
                 <!-- Start Menu shortcut to uninstall the program -->

--- a/SimpleAppSetup-mon/Components.wxs
+++ b/SimpleAppSetup-mon/Components.wxs
@@ -65,14 +65,14 @@
                 the Component unless an element overrides the value with its
                 own Directory value (not done in this example).
                 
-                Note: Use of [!SimpleAppexe] (instead of [#SimpleAppexe]) gets
-                around warning ICE69, where one component is cross-referencing
-                something in another component and both components are defined
-                in the same feature or component group.  Cross-referencing is
-                generally an error but in the specific case of shortcuts where
-                the shortcut is closely associated with the cross-referenced
-                name, this is a "safe" warning.  Using [!] essentially hides
-                the warning in this specific case.
+                Note: The target uses [!SimpleAppexe] to get around an ICE69
+                warning complaining that [#SimpleAppexe] references a file
+                in another component (but both components are in the same
+                feature; if the components were in separate features, the
+                warning would become an error).  Using [!] apparently
+                bypasses the ICE69 check and, in this case, the target is a
+                file not a registry value so [!] is basically treated the
+                same as [#].  Yes, this is a hack.
                     
                 ApplicationProgramsFolder defined in Folders.wxs.
             -->

--- a/SimpleAppSetup-mon/Components.wxs
+++ b/SimpleAppSetup-mon/Components.wxs
@@ -34,41 +34,74 @@
     <Fragment>
         <ComponentGroup Id="Components" Directory="INSTALLFOLDER">
             <Component Guid="$(var.ProductComponentGUID)">
-                <!-- The file represented by this component -->
-                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" Checksum="yes" />
+                <!--
+                    The file represented by this component.
+                    
+                    The file's location is used as the key path.  If the key
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Note: During uninstall, the file is removed by the Windows
+                    Installer.  In addition, the file's parent directories are
+                    removed so long as the parent directories are empty.  There
+                    is no need to explicitly remove the installation directory
+                    in this case.
+                -->
+                <File Id="SimpleAppexe" Source="$(var.SimpleApp.TargetPath)" KeyPath="yes" Checksum="yes" />
+            </Component>
+            <!--
+                Shortcuts need to be defined in their own component so they do
+                not interfere with installation of the application file to a
+                custom location.  Specifically, short cuts somehow interfere
+                with the application file being removed during uninstall.
+                
+                The shortcuts are still installed and uninstalled with the
+                application because it is the ComponentGroup that is associated
+                with the Main feature (in Package.wxs) and that includes all
+                the Components in the ComponentGroup.
+                
+                Note: The Directory value is used on all elements defined in
+                the Component unless an element overrides the value with its
+                own Directory value (not done in this example).
+                    
+                ApplicationProgramsFolder defined in Folders.wxs.
+            -->
+            <Component Id="Shortcuts" Directory="ApplicationProgramsFolder">
                 <!-- Start Menu shortcut to run the program -->
-                <Shortcut Id="ApplicationStartMenuShortcut" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="ApplicationStartMenuShortcut" Advertise="no"
                     Icon="icon.ico" Name="$(var.Name)"
                     Description="Launch $(var.Name) application"
                     Target="[#SimpleAppexe]"
                     Arguments="--pause"
                     WorkingDirectory="INSTALLFOLDER" />
                 <!-- Start Menu shortcut to uninstall the program -->
-                <Shortcut Id="UninstallProduct" Directory="ApplicationProgramsFolder" Advertise="no"
+                <Shortcut Id="UninstallProduct" Advertise="no"
                     Icon="icon.ico"
                     Name="$(var.Name) uninstall"
                     Description="Uninstalls $(var.Name)"
                     Target="[System64Folder]msiexec.exe"
                     Arguments="/x [ProductCode]" />
                 <!--
-                    Program folder to remove during uninstall.
-                    INSTALLFOLDER defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="INSTALLFOLDER" On="uninstall" />
-                <!--
-                    Start Menu folder to remove during uninstall.
-                    ApplicationProgramsFolder defined in Folders.wxs.
-                -->
-                <RemoveFolder Id="ApplicationProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
-                <!--
                     Define the key path for the parent component.  If the key
-                    path is not present, the component is not installed;
-                    otherwise, if the key path is present, the installer
-                    performs an upgrade, repair, or remove.
+                    path is not present, the component is considered as not
+                    being installed; otherwise, if the key path is present, the
+                    installer performs an upgrade, repair, or remove.
+                    
+                    Shortcuts require a registry-based key path; the
+                    application's own path can be a key path but that key path
+                    cannot be used with shortcuts.
 
                     Note: A key path must be unique across all components.
                 -->
                 <RegistryValue Root="HKCU" Key="Software\$(var.Manufacturer)\$(var.Name)" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+                <!--
+                    Start Menu folder to remove during uninstall.  This removes
+                    the shortcuts.  For shortcuts, the remove folder step must
+                    be explicitly given, unlike components that contain
+                    explicit files.
+                -->
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />
             </Component>
         </ComponentGroup>
         <!--

--- a/SimpleAppSetup-mon/Folders.wxs
+++ b/SimpleAppSetup-mon/Folders.wxs
@@ -23,16 +23,22 @@
         <StandardDirectory Id="ProgramFiles6432Folder">
             <!--
                 This dictates the name of the folder where the application file
-                is to be installed.  32-bit and 64-bit versions end up in
-                different root folders (due to the ProgramFiles6432Folder ID
-                above), so a simplified name is okay.  So use
-                $(var.InstallFolderName) instead of !(bind.Property.ProductName).
-                Also, add a '\' between the Manufacturer and the application
-                folder name.
-            
-                INSTALLFOLDER is defined in Predefines.wxi.
+                is to be installed by default.  32-bit and 64-bit versions end
+                up in different root folders (due to the ProgramFiles6432Folder
+                ID above), so a simplified name is okay, which means using a
+                variable $(var.InstallFolderName) instead of a property
+                !(bind.Property.ProductName).
                 
-                Note: bind.Property.ProductName comes from <Package Name="">.
+                Also, remember to add a '\' between the Manufacturer and the
+                application folder name since a folder is being defined here.
+                This way, it is possible to install to an entirely different
+                parent folder from C:\Program Files\[Manufacturer] but still
+                use the InstallFolderName as a sub-folder.
+            
+                InstallFolderName is defined in Predefines.wxi.
+                
+                Note: the Manufacturer property comes from the
+                <Package Manufacturer=""> value.
             -->
             <Directory Id="INSTALLFOLDER" Name="!(bind.Property.Manufacturer)\$(var.InstallFolderName)" />
         </StandardDirectory>


### PR DESCRIPTION
This resolves #4 where installing to a custom location prevents the application from being deleted when uninstalling.  The basic fix is to move the definitions of the shortcuts into their own Component, separate from the application Component to remove some kind of order dependency that is probably preventing the application file from being deleted during uninstall.

Also updated the README to add note about WiX Toolset v6 Maintainer Fees and to provide a hint on how to debug installation problems using msiexec and logging (thank you, @bobhairgrove).